### PR TITLE
A much faster SSCHA code when minim_dyn = False

### DIFF
--- a/Modules/Ensemble.py
+++ b/Modules/Ensemble.py
@@ -218,6 +218,9 @@ class Ensemble:
 
         if name == "dyn_0":
             self.w_0, self.pols_0 = value.DiagonalizeSupercell()
+            self.current_dyn = value.Copy()
+            self.current_w = self.w_0.copy()
+            self.current_pols = self.pols_0.copy()
 
 
     def convert_units(self, new_units):

--- a/Modules/Ensemble.py
+++ b/Modules/Ensemble.py
@@ -129,7 +129,8 @@ class Ensemble:
         self.units = UNITS_DEFAULT
         self.w_0 = None
         self.pols_0 = None
-
+        self.current_w = None
+        self.current_pols = None
         
         self.sscha_energies = []
         self.sscha_forces = []
@@ -1227,6 +1228,8 @@ Error, the following stress files are missing from the ensemble:
 
         if changed_dyn:
             w_new, pols = new_dynamical_matrix.DiagonalizeSupercell()#new_super_dyn.DyagDinQ(0)
+            self.current_w = w_new.copy()
+            self.current_pols = pols.copy()
         else:
             w_new = self.w_0.copy()
             pols = self.pols_0.copy()

--- a/Modules/Minimizer.py
+++ b/Modules/Minimizer.py
@@ -230,7 +230,7 @@ Error, increment must be bigger than 1 and decrement lower than 1.
                 self.step *= self.decrement_step
 
                 if self.verbose:
-                    print("Step too large, reducing to {}".format(self.step))
+                    print("Step too large (scalar = {} | kl_ratio = {}), reducing to {}".format(scalar, kl_ratio, self.step))
             else:
                 # The step is good, therefore next step perform a new direction
                 self.new_direction = True

--- a/Modules/Minimizer.py
+++ b/Modules/Minimizer.py
@@ -231,6 +231,8 @@ Error, increment must be bigger than 1 and decrement lower than 1.
 
                 if self.verbose:
                     print("Step too large (scalar = {} | kl_ratio = {}), reducing to {}".format(scalar, kl_ratio, self.step))
+                    print("Direction: ", self.direction)
+                    print("Gradient: ", gradient)
             else:
                 # The step is good, therefore next step perform a new direction
                 self.new_direction = True

--- a/Modules/SchaMinimizer.py
+++ b/Modules/SchaMinimizer.py
@@ -1270,9 +1270,13 @@ WARNING, the preconditioning is activated together with a root representation.
                                                   self.dyn.structure.coords[i,2]))
             print ()
             print (" ==== FINAL FREQUENCIES [cm-1] ==== ")
-            super_dyn = self.dyn.GenerateSupercellDyn(self.ensemble.supercell)
-            w, pols = super_dyn.DyagDinQ(0)
-            trans = CC.Methods.get_translations(pols, super_dyn.structure.get_masses_array())
+            #super_dyn = self.dyn.GenerateSupercellDyn(self.ensemble.supercell)
+            super_struct = self.dyn.structure.generate_supercell(self.dyn.GetSupercell())
+            w = self.ensemble.current_w.copy()
+            pols = self.ensemble.current_pols.copy()
+
+            #w, pols = super_dyn.DyagDinQ(0)
+            trans = CC.Methods.get_translations(pols, super_struct.get_masses_array())
             
             for i in range(len(w)):
                 print ("Mode %5d:   freq %16.8f cm-1  | is translation? " % (i+1, w[i] * __RyToCm__), trans[i])
@@ -1280,16 +1284,21 @@ WARNING, the preconditioning is activated together with a root representation.
             print ()
         
             
-
     def check_imaginary_frequencies(self):
         """
         The following subroutine check if the current matrix has imaginary frequency. In this case
         the minimization is stopped.
         """
 
+        # Avoid the check if the dynamical matrix has been computed.
+        if not self.minim_dyn:
+            return False 
+
         # Get the frequencies
         #superdyn = self.dyn.GenerateSupercellDyn(self.ensemble.supercell)
-        w, pols = self.dyn.DiagonalizeSupercell()#.DyagDinQ(0)
+        w = self.ensemble.current_w.copy()
+        pols = self.ensemble.current_pols.copy()
+        #w, pols = self.dyn.DiagonalizeSupercell()#.DyagDinQ(0)
         ss = self.dyn.structure.generate_supercell(self.dyn.GetSupercell())
 
         # Get translations
@@ -1308,7 +1317,9 @@ WARNING, the preconditioning is activated together with a root representation.
         if w[0] < 0:
             print ("Total frequencies (excluding translations):")
             #superdyn0 = self.ensemble.dyn_0.GenerateSupercellDyn(self.ensemble.supercell)
-            wold, pold = self.ensemble.dyn_0.DiagonalizeSupercell()# superdyn0.DyagDinQ(0)
+            wold = self.ensemble.w_0.copy()
+            pold = self.ensemble.pols_0.copy()
+            #wold, pold = self.ensemble.dyn_0.DiagonalizeSupercell()# superdyn0.DyagDinQ(0)
 
             ss0 = self.ensemble.dyn_0.structure.generate_supercell(self.dyn.GetSupercell())
             

--- a/Modules/SchaMinimizer.py
+++ b/Modules/SchaMinimizer.py
@@ -419,7 +419,7 @@ class SSCHA_Minimizer(object):
             # Preconditionate the gradient for the wyckoff minimization
             if self.precond_wyck:
                 w_pols = None
-                if len(self.q_tot) == 1:
+                if len(self.dyn.q_tot) == 1:
                     w_pols = (self.ensemble.current_w, self.ensemble.current_pols)
                 struct_precond = GetStructPrecond(self.ensemble.current_dyn, ignore_small_w = self.ensemble.ignore_small_w, w_pols = w_pols)
                 struct_grad_precond = struct_precond.dot(struct_grad_reshaped)


### PR DESCRIPTION
This branch should divide / 2 the simulation time step occurring during the Rho update, due to the absence of the dyagonalization of the starting dynamical matrix. Moreover, if the current dynamical matrix is the same as the original one, no diagonalization is performed at all in the step update.