### PR TITLE
`Examples`: add a sscha-aiida example

### DIFF
--- a/Examples/sscha_and_aiida/README.md
+++ b/Examples/sscha_and_aiida/README.md
@@ -1,0 +1,48 @@
+# Instructions
+
+We provide here the script `run_aiida_sscha.py`, which performs a thermal expansion calculation using SSCHA and aiida-quantumespresso. 
+
+It is preferable to execute the example that you already have some experience with both the SSCHA and AiiDA-QuantumEspresso codes. Nevertheless, you can try following the instructions and to run the example.
+
+## Installation
+
+We recommend to install all the packages via `mamba` (which is based on top of `conda`). After having installed `mamba`, you can simply run the following:
+
+```console
+> mamba create -n aiida-sscha -c conda-forge python gfortran libblas lapack openmpi julia openmpi-mpicc pip numpy scipy spglib aiida-core
+> pip install ase quippy-ase cellconstructor python-sscha aiida-quantumespresso aiida-pseudo
+> mamba activate aiida-sscha
+```
+
+Then, you should configure an AiiDA profile in order to use the example script (see also Prerequisites section).
+
+## Prerequisites
+
+You need to have installed in the same environment:
+- `python-sscha`
+- `cellconstructor`
+- `aiida-core`
+- `aiida-quantumespresso`
+
+For the AiiDA part, it is essential the dameon is running and you have:
+1. Configured a computer where to run the code (e.g. on your own laptop; see `aiida-core` docs for further details)
+2. Configured a code for the `pw.x` binary, related to the computer (see `aiida-quantumespresso` docs for further details)
+3. Installed a pseupopotentials library via `aiida-pseudo`. E.g. `aiida-pseudo install -x PBEsol -v 1.3`
+
+Please refer to the aiida-core and aiida-quantumespresso for further installation instruction.
+
+## How-to run 
+
+Open the `run_aiida_sscha.py` and change the data according to your needs and local installation. Then simply
+
+```console
+> python run_aiida_sscha.py > run_aiida_sscha.log
+```
+
+Usually an actual production run would take a while. We suggest to use instead
+
+```console
+> nohup python run_aiida_sscha.py > run_aiida_sscha.log &
+```
+
+or a submit script at glance.

--- a/Examples/sscha_and_aiida/run_aiida_sscha.py
+++ b/Examples/sscha_and_aiida/run_aiida_sscha.py
@@ -1,0 +1,116 @@
+"""Example of an actual AiiDA-powered SSCHA run."""
+import os
+import numpy as np
+
+from cellconstructor.Phonons import Phonons
+from sscha.aiida_ensemble import AiiDAEnsemble
+from sscha.SchaMinimizer import SSCHA_Minimizer
+from sscha.Relax import SSCHA
+from sscha.Utilities import IOInfo
+
+from aiida import load_profile
+
+from aiida_quantumespresso.common.types import ElectronicType
+
+load_profile()
+
+# =========== DEFINITION OF INPUTS =============== #
+np.random.seed(0)
+# Define the temperature range (in K)
+t_start = 300
+t_end = 800
+delta_t = 50
+target_pressure = 0
+number_q_irreducible = 4
+kpoints_distance = 0.4 # kpoints mesh
+number_of_configurations = 100
+max_iterations = 15
+data_directory = './minimization'
+pw_code_label = 'pw_7.2@hlrn-gottingen'
+dyn_filepath = './harmonic_dyn/dynamical-matrix-'
+directory_output = "./thermal_expansion" 
+
+aiida_inputs = dict(
+    pw_code_label=pw_code_label,
+    protocol='precise',
+    overrides={
+        'pseudo_family': 'SSSP/1.3/PBEsol/precision',
+        'kpoints_distance': 0.4,
+        'pw':{
+            'parameters':{
+                'SYSTEM':{
+                    # ...
+                },
+                'ELECTRONS':{
+                    'mixing_beta': 0.7
+                },
+            },
+            'settings':{
+                'cmdline': ['-nk', '8']
+            },
+        }
+    },
+    options={
+      'resources':{
+          'num_machines': 1,
+          'num_mpiprocs_per_machine': 96,
+          'num_cores_per_mpiproc': 1
+      },
+    #   'account': 'myproject',
+      'max_wallclock_seconds': int(1*60*60),
+    },
+    electronic_type=ElectronicType.INSULATOR,
+    # group_label='Group/Where/To/Add/PwNodes', # You need to create it first
+)
+# =========== DEFINITION OF INPUTS =============== #
+
+dyn = Phonons(dyn_filepath, number_q_irreducible)
+dyn.ForcePositiveDefinite()
+dyn.Symmetrize()
+
+if not os.path.exists(directory_output):
+    os.makedirs("./thermal_expansion")
+
+# We cycle over several temperatures
+t = t_start
+volumes = [] 
+temperatures = [] 
+
+while t <= t_end:
+    # Change the temperature
+    ensemble = AiiDAEnsemble(dyn, t)
+    minim = SSCHA_Minimizer(ensemble)
+    minim.set_minimization_step(0.1)
+    relax = SSCHA(
+        minimizer=minim,
+        aiida_inputs=aiida_inputs,
+        N_configs=number_of_configurations,
+        max_pop=max_iterations,
+        save_ensemble=True,
+    )
+    # Setup the I/O
+    
+    ioinfo = IOInfo()
+    ioinfo.SetupSaving( os.path.join(directory_output, "minim_t{}".format(t))) 
+    relax.setup_custom_functions( custom_function_post = ioinfo.CFP_SaveAll)
+    # Run the NPT simulation
+    relax.vc_relax(
+        target_press = target_pressure, 
+        restart_from_ens = False,
+        ensemble_loc = f'ensembles_T{t}'
+    )
+
+    # Save the volume and temperature
+    volumes.append(relax.minim.dyn.structure.get_volume())
+    temperatures.append(t)
+    # Start the next simulation from the converged value at this temperature
+    relax.minim.dyn.save_qe(os.path.join(directory_output, f"sscha_T{t}_dyn"))
+    dyn = relax.minim.dyn
+    # Print in standard output
+    relax.minim.finalize()
+    # Update the temperature
+    t += delta_t
+    # Save the thermal expansion
+    np.savetxt(os.path.join(directory_output, "thermal_expansion.dat"),
+                np.transpose([temperatures, volumes]),
+                header = "Temperature [K]; Volume [A^3]")


### PR DESCRIPTION
An example for computing ab-initio the thermal
expansion of a material using AiiDA to submit the
`pw.x` calculations is added to document the usage of the new `aiida_ensemble` module.