### PR TITLE
Bump SSSP version to 1.3 in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,7 +168,7 @@ def sssp(aiida_profile, generate_upf_data):
                 'cutoff_rho': 240.0,
             }
 
-        label = 'SSSP/1.2/PBEsol/efficiency'
+        label = 'SSSP/1.3/PBEsol/efficiency'
         family = SsspFamily.create_from_folder(dirpath, label)
 
     family.set_cutoffs(cutoffs, stringency, unit='Ry')


### PR DESCRIPTION
Aiida-quantumespresso protocols now use SSSP v1.3 by default. The older 1.2 would make the tests to fail. A simple update of the version now fixes the aiida tests.