### PR TITLE
AiiDAEnsemble: add missing `self.init()`

### DIFF
--- a/Modules/aiida_ensemble.py
+++ b/Modules/aiida_ensemble.py
@@ -100,6 +100,7 @@ class AiiDAEnsemble(Ensemble):
             self.stress_computed = copy(self.force_computed)
 
         self._clean_runs()
+        self.init()
 
     def _clean_runs(self) -> None:
         """Clean the failed runs and print summary."""


### PR DESCRIPTION
Fixes #334

The version update v1.4.1 missed to add the new `init` function to the `compute_ensemble` method of the auxiliary class `AiiDAEnsemble`. The simple fix makes the calculation using this class comparable to the traditional `Ensemble` class.