### PR TITLE
Local cluster (2FA bypass)

### DIFF
--- a/Modules/Cluster.py
+++ b/Modules/Cluster.py
@@ -412,9 +412,9 @@ class Cluster(object):
         if on_cluster:
             cmd = self.sshcmd + " {} '{}'".format(self.hostname, cmd)
             if use_active_shell:
-                cmd = "{ssh} {host} -t '{shell} --login -c \"echo {string}\"'".format(ssh = self.sshcmd, 
+                cmd = "{ssh} {host} -t '{shell} --login -c \"{command}\"'".format(ssh = self.sshcmd, 
                          host = self.hostname, 
-                         string = parse_symbols(string), 
+                         command = parse_symbols(cmd), 
                          shell = self.terminal)
 
 

--- a/Modules/LocalCluster.py
+++ b/Modules/LocalCluster.py
@@ -15,11 +15,11 @@ class LocalCluster(Cluster.Cluster):
         """
 
         # Override the value of on_cluster
-        super().ExecuteCMD(cmd, *args, on_cluster = False, **kwargs)
+        return super().ExecuteCMD(cmd, *args, on_cluster = False, **kwargs)
 
     def copy_file(self, source, destination, server_source = False, server_dest = False, **kwargs):
         """
         Copy the files ignoring if the cluster is used.
         """
 
-        super().copy_file(source, destination, server_source = False, server_dest = False, **kwargs)
+        return super().copy_file(source, destination, server_source = False, server_dest = False, **kwargs)

--- a/Modules/LocalCluster.py
+++ b/Modules/LocalCluster.py
@@ -1,0 +1,25 @@
+import sscha.Cluster as Cluster
+import sys, os
+
+"""
+Define a local cluster class.
+This allows to mock the cluster class and run the code locally, but by
+using the same interface as the cluster class and a job scheduler like SLURM.
+"""
+
+
+class LocalCluster(Cluster.Cluster):
+    def ExecuteCMD(self, cmd, *args, on_cluster = False, **kwargs):
+        """
+        Execute a command in the local machine.
+        """
+
+        # Override the value of on_cluster
+        super().ExecuteCMD(cmd, *args, on_cluster = False, **kwargs)
+
+    def copy_file(self, source, destination, server_source = False, server_dest = False, **kwargs):
+        """
+        Copy the files ignoring if the cluster is used.
+        """
+
+        super().copy_file(source, destination, server_source = False, server_dest = False, **kwargs)


### PR DESCRIPTION
This branch improves the Cluster Module to be easier to be inherited.
Then, it introduces a new module, LocalCluster, that mocks the Cluster module, making all the submissions occur locally.
This enables the submission of jobs directly within the main job, allowing the user to run simulations inside the cluster but exploiting the scheduler.

As a similar example, all the configuration is the same as the Cluster module, except the hostname is not required:

```python
import sscha.LocalCluster

my_cluster = sscha.LocalCluster.LocalCluster("my_fake_host")  # My fake host plays no role, it could probably be removed in a future release.

# Here the same configuration for my_cluster as it is for the full cluster
# To properly submit the calculation using the scheduler
```

The ``my_cluster`` variable is then used exactly like the original cluster; however, all submissions will be done within the same cluster without any SSH command.

This is the best way to bypass the restrictions imposed by the 2FA in many clusters. It allows everything to run from inside the cluster.

Soon, a guide on how to use it in practice will be prepared.
