### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Python implementation of the sscha code"
 authors = [{name = "Lorenzo Monacelli"}] # Put here email
 readme = "README.md"
 license = {file = "LICENSE.txt"}
-requires-python = ">=3.8,<=3.12" # Updated to specify Python 3.8 to 3.12
+requires-python = ">=3.8,<3.13" # Updated to specify Python 3.8 to 3.12
 dependencies = [
     "numpy",
     "ase",


### PR DESCRIPTION
<=3.12 means that 3.12.x with x>0 would not be allowed.  Can we change this requirement to <3.13, so that python 3.12.x with any x would work? Thanks.